### PR TITLE
Clear device link when all handles to device are closed

### DIFF
--- a/ctap_hid_device.py
+++ b/ctap_hid_device.py
@@ -115,6 +115,7 @@ class CTAPHIDDevice:
         if self.reference_count == 0:
             # Clear all state
             self.channels_to_state = {}
+            self.chosen_device = None
 
     def process_hid_message(self, buffer: List[int], report_type: _ReportType) -> None:
         """Core method: handle incoming HID messages."""


### PR DESCRIPTION
This PR fixes an issue with consecutive FIDO2 logins when the security key is removed from the NFC reader between the logins.