### PR TITLE
Support Python 3.14

### DIFF
--- a/fido2_hid_bridge/bridge.py
+++ b/fido2_hid_bridge/bridge.py
@@ -20,7 +20,8 @@ def main():
                         help='Enable debug messages')
     args = parser.parse_args()
     logging.basicConfig(level=args.debug)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.run_until_complete(run_device())
     loop.run_forever()
 


### PR DESCRIPTION
Since Python 3.14, `asyncio.get_event_loop()` raises a runtime error if there is no current event loop. This commit creates an event loop before attempting to use it.