### PR TITLE
Support Python 3.14+ and implement systemd notify

### DIFF
--- a/fido2-hid-bridge.service
+++ b/fido2-hid-bridge.service
@@ -6,7 +6,7 @@ Requires=pcscd.service
 [Service]
 WorkingDirectory=/opt/fido2-hid-bridge
 ExecStart=/opt/fido2-hid-bridge/.venv/bin/fido2-hid-bridge
-Type=simple
+Type=notify
 Restart=on-failure
 RestartSec=60s
 

--- a/fido2_hid_bridge/bridge.py
+++ b/fido2_hid_bridge/bridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import argparse
+import signal
 
 from fido2_hid_bridge.ctap_hid_device import CTAPHIDDevice
 
@@ -13,6 +14,36 @@ async def run_device() -> None:
 
     await device.start()
 
+    stop_event = asyncio.Event()
+
+    def signal_handler(sig):
+        logging.info(f"Received signal {sig.name}, shutting down...")
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, lambda s=sig: signal_handler(s))
+        except NotImplementedError:
+            pass
+
+    logging.info("FIDO2 HID Bridge started successfully")
+    
+    # Notify systemd, if possible
+    try:
+        import sd_notify
+        notify = sd_notify.Notifier()
+        if notify.enabled():
+            notify.ready()
+            logging.info("Notified systemd: service is ready")
+    except ImportError:
+        pass
+
+    await stop_event.wait()
+
+    logging.info("FIDO2 HID Bridge shutting down...")
+
 
 def main():
     parser = argparse.ArgumentParser(description='Relay USB-HID packets to PC/SC', allow_abbrev=False)
@@ -20,8 +51,6 @@ def main():
                         help='Enable debug messages')
     args = parser.parse_args()
     logging.basicConfig(level=args.debug)
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(run_device())
-    loop.run_forever()
+    
+    asyncio.run(run_device())
 

--- a/fido2_hid_bridge/bridge.py
+++ b/fido2_hid_bridge/bridge.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import argparse
 import signal
+from functools import partial
 
 from fido2_hid_bridge.ctap_hid_device import CTAPHIDDevice
 
@@ -24,7 +25,7 @@ async def run_device() -> None:
 
     for sig in (signal.SIGTERM, signal.SIGINT):
         try:
-            loop.add_signal_handler(sig, lambda s=sig: signal_handler(s))
+            loop.add_signal_handler(sig, partial(signal_handler, sig))
         except NotImplementedError:
             pass
 


### PR DESCRIPTION
## Summary

This PR adds Python 3.14+ compatibility and improves systemd integration.

## Changes

### Python 3.14 Compatibility

Replaces deprecated `asyncio.get_event_loop()` and `loop.run_forever()` with `asyncio.run()`.

### Systemd Integration
- Adds `Type=notify` to the service file
- Implements `sd-notify` for systemd service ready signaling 
- Implements graceful shutdown on SIGTERM/SIGINT signals

This fixes an issue I experianced where systemd would treat the service as hung and restart-loop and not cleanly shut it down.

## Dependencies

Added `sd-notify = "^0.1.0"`